### PR TITLE
Feature/tool description development

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolsClient.java
@@ -1,15 +1,18 @@
 package com.github.jmchilton.blend4j.galaxy;
 
-import com.github.jmchilton.blend4j.galaxy.beans.History;
-import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
-import com.github.jmchilton.blend4j.galaxy.beans.ToolInputs;
-import com.sun.jersey.api.client.ClientResponse;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.github.jmchilton.blend4j.galaxy.beans.History;
+import com.github.jmchilton.blend4j.galaxy.beans.Tool;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolInputs;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolSection;
+import com.sun.jersey.api.client.ClientResponse;
 
 public interface ToolsClient {
   ToolExecution create(History history, ToolInputs inputs);
@@ -28,6 +31,21 @@ public interface ToolsClient {
   ClientResponse uploadRequest(FileUploadRequest request);
   
   ToolExecution upload(FileUploadRequest request);
+  
+  /**
+   * Show details about the specified tool.
+   * 
+   * @param toolId the tool to look up.
+   * @return details about the tool.
+   */
+  Tool showTool(final String toolId);
+  
+  /**
+   * Get a list of all tools installed in Galaxy.
+   * 
+   * @return the list of tools installed in Galaxy.
+   */
+  List<ToolSection> getTools();
   
   public static class UploadFile {
     private final File file;

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolsClientImpl.java
@@ -1,12 +1,18 @@
 package com.github.jmchilton.blend4j.galaxy;
 
-import com.github.jmchilton.blend4j.galaxy.beans.History;
-import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
-import com.github.jmchilton.blend4j.galaxy.beans.ToolInputs;
-import com.sun.jersey.api.client.ClientResponse;
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import org.codehaus.jackson.type.TypeReference;
+
+import com.github.jmchilton.blend4j.galaxy.beans.History;
+import com.github.jmchilton.blend4j.galaxy.beans.Tool;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolInputs;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolSection;
+import com.sun.jersey.api.client.ClientResponse;
 
 class ToolsClientImpl extends Client implements ToolsClient {
   ToolsClientImpl(GalaxyInstanceImpl galaxyInstance) {
@@ -52,5 +58,16 @@ class ToolsClientImpl extends Client implements ToolsClient {
     requestParameters.put("type", "upload_dataset");
     return multipartPost(getWebResource(), requestParameters, prepareUploads(request.getFileObjects()));
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public Tool showTool(final String toolId) {
+    return super.getWebResource(toolId).get(Tool.class);
+  }
 
+  
+  public List<ToolSection> getTools() {
+	return get(new TypeReference<List<ToolSection>>() {});
+  }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Tool.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Tool.java
@@ -1,0 +1,62 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Tool extends GalaxyObject {
+	private String version;
+
+	private String description;
+
+	private String name;
+	
+	private String link;
+	
+	private String target;
+	
+	@JsonProperty("link")
+	protected void setLink(final String link) {
+		this.link = link;
+	}
+	
+	public String getLink() {
+		return this.link;
+	}
+	
+	@JsonProperty("target")
+	protected void setTarget(final String target) {
+		this.target = target;
+	}
+	
+	public String getTarget() {
+		return this.target;
+	}
+
+	@JsonProperty("description")
+	protected void setDescription(final String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	@JsonProperty("version")
+	protected void setVersion(final String version) {
+		this.version = version;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	@JsonProperty("name")
+	protected void setName(final String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/ToolSection.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/ToolSection.java
@@ -1,0 +1,63 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.github.jmchilton.blend4j.galaxy.ToolsClient;
+
+/**
+ * Very basic details about tools. For more information about a tool, load a
+ * {@link ToolDetails} instance with {@link ToolsClient#showTool}.
+ * 
+ * @author Franklin Bristow franklin.bristow@phac-aspc.gc.ca
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToolSection extends GalaxyObject {
+	private String version;
+
+	private String name;
+	
+	private String description;
+	
+	private List<Tool> elems;
+	
+	@JsonProperty("description")
+	protected void setDescription(final String description) {
+		this.description = description;
+	}
+	
+	public String getDescription() {
+		return this.description;
+	}
+	
+	@JsonProperty("elems")
+	protected void setElems(final List<Tool> elems) {
+		this.elems = elems;
+	}
+	
+	public List<Tool> getElems() {
+		return this.elems;
+	}
+
+	
+	@JsonProperty("version")
+	protected void setVersion(final String version) {
+		this.version = version;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	@JsonProperty("name")
+	protected void setName(final String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+}

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
@@ -128,7 +128,7 @@ public class TestGalaxyInstance {
 
   static String getProperty(final String key, final String defaultValue) {
     String value = defaultValue;
-    if(System.getProperties().contains(key)) {
+    if(System.getProperties().getProperty(key) != null) {
       value = System.getProperties().getProperty(key);
     } else if(properties.containsKey(key)) {
       value = properties.getProperty(key);

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolsTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolsTest.java
@@ -1,14 +1,17 @@
 package com.github.jmchilton.blend4j.galaxy;
 
-import com.github.jmchilton.blend4j.galaxy.ToolsClient.FileUploadRequest;
-import com.github.jmchilton.blend4j.galaxy.beans.History;
-import com.github.jmchilton.blend4j.galaxy.beans.OutputDataset;
-import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
-import com.sun.jersey.api.client.ClientResponse;
 import java.io.File;
 import java.util.List;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.github.jmchilton.blend4j.galaxy.ToolsClient.FileUploadRequest;
+import com.github.jmchilton.blend4j.galaxy.beans.OutputDataset;
+import com.github.jmchilton.blend4j.galaxy.beans.Tool;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolExecution;
+import com.github.jmchilton.blend4j.galaxy.beans.ToolSection;
+import com.sun.jersey.api.client.ClientResponse;
 
 public class ToolsTest {
   private GalaxyInstance instance;
@@ -49,5 +52,26 @@ public class ToolsTest {
     final FileUploadRequest request = new FileUploadRequest(historyId, testFile);
     return request;
   }
-
+  
+  @Test
+  public void testGetTools() {
+	final List<ToolSection> tools = client.getTools();
+	assert tools != null;
+	assert ! tools.isEmpty();
+	
+	for (final ToolSection tool : tools) {
+		assert tool.getId() != null;
+	}
+  }
+  
+  @Test
+  public void testGetToolDetails() {
+	  final List<ToolSection> tools = client.getTools();
+	  // pick an arbitrary tool to get details about.
+	  final Tool toolDetails = client.showTool(tools.iterator().next().getElems().iterator().next().getId());
+	  
+	  assert toolDetails != null;
+	  assert toolDetails.getName() != null;
+	  assert toolDetails.getVersion() != null;
+  }
 }


### PR DESCRIPTION
Implements basic tool-related access for Galaxy.

Tool collections can be accessed by `ToolsClient#getTools()`. This returns a `ToolSection` that corresponds to a collection of tools in Galaxy.

Individual tools can be accessed by `ToolsClient#showTool(String)`.
