### PR TITLE
Feature/delete galaxy objects

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -61,24 +61,22 @@ public class BaseClient {
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
-   * @param body The body of the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource, String body) {
-    return deleteResponse(webResource, true, body);
+  protected ClientResponse deleteResponse(final WebResource webResource) {
+    return deleteResponse(webResource, true);
   }
   
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
    * @param checkResponse True if an exception should be thrown on failure, false otherwise.
-   * @param body The body of the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse, String body) {
-    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class, body);
+  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse) {
+    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class);
     if(checkResponse) {
       this.checkResponse(response);
     }

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -58,6 +58,31 @@ public class BaseClient {
     return get(getWebResource(), typeReference);
   }
   
+  /**
+   * Gets the response for a DELETE request.
+   * @param webResource The {@link WebResource} to send the request to.
+   * @return The {@link ClientResponse} for this request.
+   * @throws ResponseException If the response was not successful.
+   */
+  protected ClientResponse deleteResponse(final WebResource webResource) {
+    return deleteResponse(webResource, true);
+  }
+  
+  /**
+   * Gets the response for a DELETE request.
+   * @param webResource The {@link WebResource} to send the request to.
+   * @param checkResponse True if an exception should be thrown on failure, false otherwise.
+   * @return The {@link ClientResponse} for this request.
+   * @throws ResponseException If the response was not successful.
+   */
+  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse) {
+    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class);
+    if(checkResponse) {
+      this.checkResponse(response);
+    }
+    return response;
+  }
+  
   protected ClientResponse getResponse(final WebResource webResource) {
     return getResponse(webResource, true);
   }

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -61,24 +61,24 @@ public class BaseClient {
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
-   * @param object A list of key/value parameters for the delete request.
+   * @param body The body of the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource, Map<String,Boolean> params) {
-    return deleteResponse(webResource, true, params);
+  protected ClientResponse deleteResponse(final WebResource webResource, String body) {
+    return deleteResponse(webResource, true, body);
   }
   
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
    * @param checkResponse True if an exception should be thrown on failure, false otherwise.
-   * @param params A list of key/value parameters for the delete request.
+   * @param body The body of the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse, Map<String,Boolean> params) {
-    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class, write(params));
+  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse, String body) {
+    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class, body);
     if(checkResponse) {
       this.checkResponse(response);
     }

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -61,22 +61,24 @@ public class BaseClient {
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
+   * @param object A list of key/value parameters for the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource) {
-    return deleteResponse(webResource, true);
+  protected ClientResponse deleteResponse(final WebResource webResource, Map<String,Boolean> params) {
+    return deleteResponse(webResource, true, params);
   }
   
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.
    * @param checkResponse True if an exception should be thrown on failure, false otherwise.
+   * @param params A list of key/value parameters for the delete request.
    * @return The {@link ClientResponse} for this request.
    * @throws ResponseException If the response was not successful.
    */
-  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse) {
-    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class);
+  protected ClientResponse deleteResponse(final WebResource webResource, final boolean checkResponse, Map<String,Boolean> params) {
+    final ClientResponse response = webResource.accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class, write(params));
     if(checkResponse) {
       this.checkResponse(response);
     }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -38,20 +38,18 @@ public interface HistoriesClient {
   HistoryExport exportHistory(String historyId);
   
   /**
-   * Deletes the given History from Galaxy.
+   * Deletes the given History from Galaxy (this will not purge).
    * @param historyId  The id of the History to delete.
-   * @param purge True if this History should also be purged, otherwise set to false.
    * @return A {@link ClientResponse} for this request.
    */
-  ClientResponse deleteHistoryResponse(String historyId, boolean purge);
+  ClientResponse deleteHistoryResponse(String historyId);
   
   /**
-   * Deletes the given History from Galaxy.
+   * Deletes the given History from Galaxy (this will not purge).
    * @param historyId  The id of the History to delete.
-   * @param purge True if this History should also be purged, otherwise set to false.
    * @return A {@link HistoryDeleteResponse} for this request.
    */
-  HistoryDeleteResponse deleteHistory(String historyId, boolean purge);
+  HistoryDeleteResponse deleteHistory(String historyId);
   
   /**
    * Gets a Dataset collection for the given historyId and datasetCollectionId.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
-import com.github.jmchilton.blend4j.galaxy.beans.DeleteResponse;
+import com.github.jmchilton.blend4j.galaxy.beans.HistoryDeleteResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryDetails;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
@@ -49,9 +49,9 @@ public interface HistoriesClient {
    * Deletes the given History from Galaxy.
    * @param historyId  The id of the History to delete.
    * @param purge True if this History should also be purged, otherwise set to false.
-   * @return A {@link DeleteResponse} for this request.
+   * @return A {@link HistoryDeleteResponse} for this request.
    */
-  DeleteResponse deleteHistory(String historyId, boolean purge);
+  HistoryDeleteResponse deleteHistory(String historyId, boolean purge);
   
   /**
    * Gets a Dataset collection for the given historyId and datasetCollectionId.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
+import com.github.jmchilton.blend4j.galaxy.beans.DeleteResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryDetails;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
@@ -43,6 +44,14 @@ public interface HistoriesClient {
    * @return A {@link ClientResponse} for this request.
    */
   ClientResponse deleteHistoryRequest(String historyId, boolean purge);
+  
+  /**
+   * Deletes the given History from Galaxy.
+   * @param historyId  The id of the History to delete.
+   * @param purge True if this History should also be purged, otherwise set to false.
+   * @return A {@link DeleteResponse} for this request.
+   */
+  DeleteResponse deleteHistory(String historyId, boolean purge);
   
   /**
    * Gets a Dataset collection for the given historyId and datasetCollectionId.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -43,7 +43,7 @@ public interface HistoriesClient {
    * @param purge True if this History should also be purged, otherwise set to false.
    * @return A {@link ClientResponse} for this request.
    */
-  ClientResponse deleteHistoryRequest(String historyId, boolean purge);
+  ClientResponse deleteHistoryResponse(String historyId, boolean purge);
   
   /**
    * Deletes the given History from Galaxy.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -42,7 +42,7 @@ public interface HistoriesClient {
    * @param historyId  The id of the History to delete.
    * @return A {@link ClientResponse} for this request.
    */
-  ClientResponse deleteHistoryResponse(String historyId);
+  ClientResponse deleteHistoryRequest(String historyId);
   
   /**
    * Deletes the given History from Galaxy (this will not purge).

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -37,6 +37,14 @@ public interface HistoriesClient {
   HistoryExport exportHistory(String historyId);
   
   /**
+   * Deletes the given History from Galaxy.
+   * @param historyId  The id of the History to delete.
+   * @param purge True if this History should also be purged, otherwise set to false.
+   * @return A {@link ClientResponse} for this request.
+   */
+  ClientResponse deleteHistoryRequest(String historyId, boolean purge);
+  
+  /**
    * Gets a Dataset collection for the given historyId and datasetCollectionId.
    * @param historyId  The ID of the history to search for dataset collections.
    * @param datasetCollectionId  The id of the dataset collection to search for.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClient.java
@@ -38,15 +38,25 @@ public interface HistoriesClient {
   HistoryExport exportHistory(String historyId);
   
   /**
-   * Deletes the given History from Galaxy (this will not purge).
-   * @param historyId  The id of the History to delete.
-   * @return A {@link ClientResponse} for this request.
+   * Deletes the given History from Galaxy (this will not purge). This will
+   * return a {@link ClientResponse} object providing access to the status code
+   * and the non-serialized body of the response.
+   * 
+   * @param historyId
+   *          The id of the History to delete.
+   * @return A {@link ClientResponse} for this request. The status code provided
+   *         by {@link ClientResponse#getClientResponseStatus()} should be
+   *         verified for success.
    */
   ClientResponse deleteHistoryRequest(String historyId);
-  
+
   /**
-   * Deletes the given History from Galaxy (this will not purge).
-   * @param historyId  The id of the History to delete.
+   * Deletes the given History from Galaxy (this will not purge). This will
+   * return a {@link HistoryDeleteResponse} object for the delete request with
+   * information provided by Galaxy.
+   * 
+   * @param historyId
+   *          The id of the History to delete.
    * @return A {@link HistoryDeleteResponse} for this request.
    */
   HistoryDeleteResponse deleteHistory(String historyId);

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -118,4 +118,9 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
     FileWriter fr = new FileWriter(downloadedFile);
     fr.close();
   }
+
+  @Override
+  public ClientResponse deleteHistoryRequest(String historyId, boolean purge) {
+  	return deleteResponse(getWebResource(historyId));
+  }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.codehaus.jackson.type.TypeReference;
 
 import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
-import com.github.jmchilton.blend4j.galaxy.beans.DeleteResponse;
+import com.github.jmchilton.blend4j.galaxy.beans.HistoryDeleteResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryDetails;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
@@ -128,11 +128,11 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
     if (purge) {
       deleteStatus.put("purge", true);
     }
-  	return deleteResponse(getWebResource(historyId), deleteStatus);
+  	return deleteResponse(getWebResource(historyId), write(deleteStatus));
   }
   
   @Override
-  public DeleteResponse deleteHistory(String historyId, boolean purge) {
-    return deleteHistoryRequest(historyId, purge).getEntity(DeleteResponse.class);
+  public HistoryDeleteResponse deleteHistory(String historyId, boolean purge) {
+    return deleteHistoryRequest(historyId, purge).getEntity(HistoryDeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -3,7 +3,9 @@ package com.github.jmchilton.blend4j.galaxy;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.codehaus.jackson.type.TypeReference;
 
@@ -122,11 +124,15 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
 
   @Override
   public ClientResponse deleteHistoryRequest(String historyId, boolean purge) {
-  	return deleteResponse(getWebResource(historyId));
+    Map<String,Boolean> deleteStatus = new HashMap<String,Boolean>();
+    if (purge) {
+      deleteStatus.put("purge", true);
+    }
+  	return deleteResponse(getWebResource(historyId), deleteStatus);
   }
   
   @Override
   public DeleteResponse deleteHistory(String historyId, boolean purge) {
-    return deleteResponse(getWebResource(historyId)).getEntity(DeleteResponse.class);
+    return deleteHistoryRequest(historyId, purge).getEntity(DeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.codehaus.jackson.type.TypeReference;
 
 import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
+import com.github.jmchilton.blend4j.galaxy.beans.DeleteResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryDetails;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
@@ -122,5 +123,10 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   @Override
   public ClientResponse deleteHistoryRequest(String historyId, boolean purge) {
   	return deleteResponse(getWebResource(historyId));
+  }
+  
+  @Override
+  public DeleteResponse deleteHistory(String historyId, boolean purge) {
+    return deleteResponse(getWebResource(historyId)).getEntity(DeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -119,12 +119,12 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   }
 
   @Override
-  public ClientResponse deleteHistoryResponse(String historyId) {
+  public ClientResponse deleteHistoryRequest(String historyId) {
   	return deleteResponse(getWebResource(historyId));
   }
   
   @Override
   public HistoryDeleteResponse deleteHistory(String historyId) {
-    return deleteHistoryResponse(historyId).getEntity(HistoryDeleteResponse.class);
+    return deleteHistoryRequest(historyId).getEntity(HistoryDeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -3,9 +3,7 @@ package com.github.jmchilton.blend4j.galaxy;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.codehaus.jackson.type.TypeReference;
 
@@ -17,9 +15,7 @@ import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContentsProvenance;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryDataset;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryExport;
-import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionElement;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionDescription;
-import com.github.jmchilton.blend4j.galaxy.beans.collection.request.HistoryDatasetElement;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.CollectionResponse;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
@@ -123,16 +119,12 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   }
 
   @Override
-  public ClientResponse deleteHistoryResponse(String historyId, boolean purge) {
-    Map<String,Boolean> deleteStatus = new HashMap<String,Boolean>();
-    if (purge) {
-      deleteStatus.put("purge", true);
-    }
-  	return deleteResponse(getWebResource(historyId), write(deleteStatus));
+  public ClientResponse deleteHistoryResponse(String historyId) {
+  	return deleteResponse(getWebResource(historyId));
   }
   
   @Override
-  public HistoryDeleteResponse deleteHistory(String historyId, boolean purge) {
-    return deleteHistoryResponse(historyId, purge).getEntity(HistoryDeleteResponse.class);
+  public HistoryDeleteResponse deleteHistory(String historyId) {
+    return deleteHistoryResponse(historyId).getEntity(HistoryDeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -123,7 +123,7 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   }
 
   @Override
-  public ClientResponse deleteHistoryRequest(String historyId, boolean purge) {
+  public ClientResponse deleteHistoryResponse(String historyId, boolean purge) {
     Map<String,Boolean> deleteStatus = new HashMap<String,Boolean>();
     if (purge) {
       deleteStatus.put("purge", true);
@@ -133,6 +133,6 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   
   @Override
   public HistoryDeleteResponse deleteHistory(String historyId, boolean purge) {
-    return deleteHistoryRequest(historyId, purge).getEntity(HistoryDeleteResponse.class);
+    return deleteHistoryResponse(historyId, purge).getEntity(HistoryDeleteResponse.class);
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
@@ -70,5 +70,5 @@ public interface LibrariesClient {
    * @param libraryId The id of the library to delete.
    * @return A {@link ClientResponse} for the deleted library.
    */
-  ClientResponse deleteLibraryResponse(String libraryId);
+  ClientResponse deleteLibraryRequest(String libraryId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
@@ -70,5 +70,5 @@ public interface LibrariesClient {
    * @param libraryId The id of the library to delete.
    * @return A {@link ClientResponse} for the deleted library.
    */
-  ClientResponse deleteLibraryRequest(String libraryId);
+  ClientResponse deleteLibraryResponse(String libraryId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
@@ -66,9 +66,15 @@ public interface LibrariesClient {
   LibraryDataset showDataset(String libraryId, String datasetId);
   
   /**
-   * Deletes the given library from Galaxy.
-   * @param libraryId The id of the library to delete.
-   * @return A {@link ClientResponse} for the deleted library.
+   * Deletes the given library from Galaxy (this is irreversible). This will return a
+   * {@link ClientResponse} object providing access to the status code and the
+   * non-serialized body of the response.
+   * 
+   * @param libraryId
+   *          The id of the library to delete.
+   * @return A {@link ClientResponse} for the deleted library. The status code
+   *         provided by {@link ClientResponse#getClientResponseStatus()} should
+   *         be verified for success.
    */
   ClientResponse deleteLibraryRequest(String libraryId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClient.java
@@ -53,7 +53,7 @@ public interface LibrariesClient {
    * Gets a ClientResponse object for a request to show details on a dataset within a Library.
    * @param libraryId  The id of the Library the dataset is located within.
    * @param datasetId  The id of the dataset to get details.
-   * @return A @{link ClientResponse} object representing details on the showDatasets request.
+   * @return A {@link ClientResponse} object representing details on the showDatasets request.
    */
   ClientResponse showDatasetRequest(String libraryId, String datasetId);
   
@@ -61,7 +61,14 @@ public interface LibrariesClient {
    * Gets details about a given library dataset.
    * @param libraryId  The id of the Library the dataset is located within.
    * @param datasetId  The id of the dataset to get details.
-   * @return  A @{link LibraryDataset} object representing details for this dataset.
+   * @return  A {@link LibraryDataset} object representing details for this dataset.
    */
-  LibraryDataset showDataset(String libraryId, String datasetId);  
+  LibraryDataset showDataset(String libraryId, String datasetId);
+  
+  /**
+   * Deletes the given library from Galaxy.
+   * @param libraryId The id of the library to delete.
+   * @return A {@link ClientResponse} for the deleted library.
+   */
+  ClientResponse deleteLibraryRequest(String libraryId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
@@ -117,6 +117,6 @@ class LibrariesClientImpl extends Client implements LibrariesClient {
 
   @Override
   public ClientResponse deleteLibraryRequest(String libraryId) {
-    return deleteResponse(getWebResource(libraryId), new HashMap<String, Boolean>());
+    return deleteResponse(getWebResource(libraryId), "");
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
@@ -116,7 +116,7 @@ class LibrariesClientImpl extends Client implements LibrariesClient {
   }
 
   @Override
-  public ClientResponse deleteLibraryRequest(String libraryId) {
+  public ClientResponse deleteLibraryResponse(String libraryId) {
     return deleteResponse(getWebResource(libraryId), "");
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
@@ -116,7 +116,7 @@ class LibrariesClientImpl extends Client implements LibrariesClient {
   }
 
   @Override
-  public ClientResponse deleteLibraryResponse(String libraryId) {
+  public ClientResponse deleteLibraryRequest(String libraryId) {
     return deleteResponse(getWebResource(libraryId));
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
@@ -114,4 +114,9 @@ class LibrariesClientImpl extends Client implements LibrariesClient {
   public LibraryDataset showDataset(String libraryId, String datasetId) {
     return read(showDatasetRequest(libraryId, datasetId), LibraryDataset.class);
   }
+
+  @Override
+  public ClientResponse deleteLibraryRequest(String libraryId) {
+    return deleteResponse(getWebResource(libraryId), new HashMap<String, Boolean>());
+  }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/LibrariesClientImpl.java
@@ -117,6 +117,6 @@ class LibrariesClientImpl extends Client implements LibrariesClient {
 
   @Override
   public ClientResponse deleteLibraryResponse(String libraryId) {
-    return deleteResponse(getWebResource(libraryId), "");
+    return deleteResponse(getWebResource(libraryId));
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
@@ -24,9 +24,15 @@ public interface WorkflowsClient {
   WorkflowOutputs runWorkflow(WorkflowInputs workflowInputs);
   
   /**
-   * Deletes the workflow with the given id.  This action is irreversible.
-   * @param id The id of the workflow to delete.
-   * @return A {@link ClientResponse} for this request.
+   * Deletes the workflow with the given id (this is irreversible). This will
+   * return a {@link ClientResponse} object providing access to the status code
+   * and the non-serialized body of the response.
+   * 
+   * @param id
+   *          The id of the workflow to delete.
+   * @return A {@link ClientResponse} for this request. The status code provided
+   *         by {@link ClientResponse#getClientResponseStatus()} should be
+   *         verified for success.
    */
   ClientResponse deleteWorkflowRequest(String id);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
@@ -22,4 +22,11 @@ public interface WorkflowsClient {
   ClientResponse runWorkflowResponse(WorkflowInputs workflowInputs);
 
   WorkflowOutputs runWorkflow(WorkflowInputs workflowInputs);
+  
+  /**
+   * Deletes the workflow with the given id.  This action is irreversible.
+   * @param id The id of the workflow to delete.
+   * @return A {@link ClientResponse} for this request.
+   */
+  ClientResponse deleteWorkflowResponse(String id);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClient.java
@@ -28,5 +28,5 @@ public interface WorkflowsClient {
    * @param id The id of the workflow to delete.
    * @return A {@link ClientResponse} for this request.
    */
-  ClientResponse deleteWorkflowResponse(String id);
+  ClientResponse deleteWorkflowRequest(String id);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
@@ -10,11 +10,13 @@ import com.github.jmchilton.blend4j.galaxy.beans.WorkflowInputs;
 import com.github.jmchilton.blend4j.galaxy.beans.WorkflowOutputs;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -57,5 +59,10 @@ class WorkflowsClientImpl extends Client implements WorkflowsClient {
 
   public Workflow importWorkflow(String json) {
     return importWorkflowResponse(json).getEntity(Workflow.class);
+  }
+
+  @Override
+  public ClientResponse deleteWorkflowResponse(String id) {
+    return deleteResponse(getWebResource(id), "");
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
@@ -52,7 +52,7 @@ class WorkflowsClientImpl extends Client implements WorkflowsClient {
   }
 
   @Override
-  public ClientResponse deleteWorkflowResponse(String id) {
+  public ClientResponse deleteWorkflowRequest(String id) {
     return deleteResponse(getWebResource(id));
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/WorkflowsClientImpl.java
@@ -11,16 +11,6 @@ import com.github.jmchilton.blend4j.galaxy.beans.WorkflowOutputs;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-
 class WorkflowsClientImpl extends Client implements WorkflowsClient {
   public WorkflowsClientImpl(GalaxyInstanceImpl galaxyInstance) {
     super(galaxyInstance, "workflows");
@@ -63,6 +53,6 @@ class WorkflowsClientImpl extends Client implements WorkflowsClient {
 
   @Override
   public ClientResponse deleteWorkflowResponse(String id) {
-    return deleteResponse(getWebResource(id), "");
+    return deleteResponse(getWebResource(id));
   }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/DeleteResponse.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/DeleteResponse.java
@@ -1,0 +1,32 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Defines the response from a delete request to Galaxy.
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class DeleteResponse extends GalaxyObject {
+  @JsonProperty("deleted")
+  private boolean deleted;
+  
+  @JsonProperty("purged")
+  private boolean purged;
+
+  /**
+   * Whether or not this object is deleted.
+   * @return Whether or not this object is deleted.
+   */
+  public boolean getDeleted() {
+    return deleted;
+  }
+
+  /**
+   * Whether or not this object is purged.
+   * @return Whether or not this object is purged.
+   */
+  public boolean getPurged() {
+    return purged;
+  }  
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/HistoryDeleteResponse.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/HistoryDeleteResponse.java
@@ -7,7 +7,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * Defines the response from a delete request to Galaxy.
  */
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class DeleteResponse extends GalaxyObject {
+public class HistoryDeleteResponse extends GalaxyObject {
   @JsonProperty("deleted")
   private boolean deleted;
   

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -508,6 +508,27 @@ public class HistoriesTest {
   }
   
   /**
+   * Tests out successfully purging a history.
+   */
+  @Test
+  public void testPurgeHistorySuccess() {
+    History createdHistory = historiesClient.create(new History("New History"));
+    assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
+    
+    DeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), true);
+    assert createdHistory.getId().equals(deleteResponse.getId()) : "Invalid id from delete response";
+    assert deleteResponse.getDeleted() : "Invalid deleted status from response";
+    assert deleteResponse.getPurged() : "Invalid purged status from response";
+    
+    try {
+      historiesClient.showHistory(createdHistory.getId());
+      fail("History not properly deleted");
+    } catch (UniformInterfaceException e) {
+      assert 400 == e.getResponse().getStatus() : "Invalid status code for deleted history";
+    }
+  }
+  
+  /**
    * Tests out failing to delete a non-existent history.
    */
   @Test

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -458,7 +458,7 @@ public class HistoriesTest {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    ClientResponse deleteResponse = historiesClient.deleteHistoryResponse(createdHistory.getId(), false);
+    ClientResponse deleteResponse = historiesClient.deleteHistoryResponse(createdHistory.getId());
     assert ClientResponse.Status.OK.equals(deleteResponse.getClientResponseStatus()) : "Invalid status code for deleted history";
     
     try {
@@ -479,7 +479,7 @@ public class HistoriesTest {
     assert !ClientResponse.Status.OK.equals(historiesClient.showHistoryRequest(historyId)) : "History with " + historyId + " already exists";
     
     try {
-      historiesClient.deleteHistoryResponse(historyId, false);
+      historiesClient.deleteHistoryResponse(historyId);
       fail("Deleting invalid history did not throw an exception");
     } catch (ResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";      
@@ -494,31 +494,10 @@ public class HistoriesTest {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    HistoryDeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), false);
+    HistoryDeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId());
     assert createdHistory.getId().equals(deleteResponse.getId()) : "Invalid id from delete response";
     assert deleteResponse.getDeleted() : "Invalid deleted status from response";
     assert !deleteResponse.getPurged() : "Invalid purged status from response";
-    
-    try {
-      historiesClient.showHistory(createdHistory.getId());
-      fail("History not properly deleted");
-    } catch (UniformInterfaceException e) {
-      assert 400 == e.getResponse().getStatus() : "Invalid status code for deleted history";
-    }
-  }
-  
-  /**
-   * Tests out successfully purging a history.
-   */
-  @Test
-  public void testPurgeHistorySuccess() {
-    History createdHistory = historiesClient.create(new History("New History"));
-    assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
-    
-    HistoryDeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), true);
-    assert createdHistory.getId().equals(deleteResponse.getId()) : "Invalid id from delete response";
-    assert deleteResponse.getDeleted() : "Invalid deleted status from response";
-    assert deleteResponse.getPurged() : "Invalid purged status from response";
     
     try {
       historiesClient.showHistory(createdHistory.getId());
@@ -538,7 +517,7 @@ public class HistoriesTest {
     assert !ClientResponse.Status.OK.equals(historiesClient.showHistoryRequest(historyId)) : "History with " + historyId + " already exists";
     
     try {
-      historiesClient.deleteHistory(historyId, false);
+      historiesClient.deleteHistory(historyId);
       fail("Deleting invalid history did not throw an exception");
     } catch (ResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";      

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -454,11 +454,11 @@ public class HistoriesTest {
    * Tests out successfully deleting a history and getting back a ClientRresponse.
    */
   @Test
-  public void testDeleteHistoryRequestSuccess() {
+  public void testDeleteHistoryResponseSuccess() {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    ClientResponse deleteResponse = historiesClient.deleteHistoryRequest(createdHistory.getId(), false);
+    ClientResponse deleteResponse = historiesClient.deleteHistoryResponse(createdHistory.getId(), false);
     assert ClientResponse.Status.OK.equals(deleteResponse.getClientResponseStatus()) : "Invalid status code for deleted history";
     
     try {
@@ -473,13 +473,13 @@ public class HistoriesTest {
    * Tests out failing to delete a non-existent history.
    */
   @Test
-  public void testDeleteHistoryRequestFail() {
+  public void testDeleteHistoryResponseFail() {
     String historyId = "invalid";
     
     assert !ClientResponse.Status.OK.equals(historiesClient.showHistoryRequest(historyId)) : "History with " + historyId + " already exists";
     
     try {
-      historiesClient.deleteHistoryRequest(historyId, false);
+      historiesClient.deleteHistoryResponse(historyId, false);
       fail("Deleting invalid history did not throw an exception");
     } catch (ResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";      

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -4,7 +4,7 @@ import static org.testng.AssertJUnit.*;
 
 import com.github.jmchilton.blend4j.exceptions.ResponseException;
 import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
-import com.github.jmchilton.blend4j.galaxy.beans.DeleteResponse;
+import com.github.jmchilton.blend4j.galaxy.beans.HistoryDeleteResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContentsProvenance;
@@ -494,7 +494,7 @@ public class HistoriesTest {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    DeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), false);
+    HistoryDeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), false);
     assert createdHistory.getId().equals(deleteResponse.getId()) : "Invalid id from delete response";
     assert deleteResponse.getDeleted() : "Invalid deleted status from response";
     assert !deleteResponse.getPurged() : "Invalid purged status from response";
@@ -515,7 +515,7 @@ public class HistoriesTest {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    DeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), true);
+    HistoryDeleteResponse deleteResponse = historiesClient.deleteHistory(createdHistory.getId(), true);
     assert createdHistory.getId().equals(deleteResponse.getId()) : "Invalid id from delete response";
     assert deleteResponse.getDeleted() : "Invalid deleted status from response";
     assert deleteResponse.getPurged() : "Invalid purged status from response";

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -454,11 +454,11 @@ public class HistoriesTest {
    * Tests out successfully deleting a history and getting back a ClientRresponse.
    */
   @Test
-  public void testDeleteHistoryResponseSuccess() {
+  public void testDeleteHistoryRequestSuccess() {
     History createdHistory = historiesClient.create(new History("New History"));
     assert historiesClient.showHistory(createdHistory.getId()) != null : "History not properly created";
     
-    ClientResponse deleteResponse = historiesClient.deleteHistoryResponse(createdHistory.getId());
+    ClientResponse deleteResponse = historiesClient.deleteHistoryRequest(createdHistory.getId());
     assert ClientResponse.Status.OK.equals(deleteResponse.getClientResponseStatus()) : "Invalid status code for deleted history";
     
     try {
@@ -473,13 +473,13 @@ public class HistoriesTest {
    * Tests out failing to delete a non-existent history.
    */
   @Test
-  public void testDeleteHistoryResponseFail() {
+  public void testDeleteHistoryRequestFail() {
     String historyId = "invalid";
     
     assert !ClientResponse.Status.OK.equals(historiesClient.showHistoryRequest(historyId)) : "History with " + historyId + " already exists";
     
     try {
-      historiesClient.deleteHistoryResponse(historyId);
+      historiesClient.deleteHistoryRequest(historyId);
       fail("Deleting invalid history did not throw an exception");
     } catch (ResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";      

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
@@ -1,5 +1,7 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import static org.testng.AssertJUnit.*;
+
 import com.github.jmchilton.blend4j.galaxy.beans.FileLibraryUpload;
 import com.github.jmchilton.blend4j.galaxy.beans.FilesystemPathsLibraryUpload;
 import com.github.jmchilton.blend4j.galaxy.beans.Library;
@@ -8,6 +10,7 @@ import com.github.jmchilton.blend4j.galaxy.beans.LibraryDataset;
 import com.github.jmchilton.blend4j.galaxy.beans.LibraryFolder;
 import com.github.jmchilton.blend4j.galaxy.beans.LibraryUpload;
 import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
 
 import java.io.File;
 import java.util.List;
@@ -108,6 +111,34 @@ public class LibrariesTest {
       Assert.assertEquals("tabular", libraryDataset.getDataTypeExt());
       Assert.assertNotNull(libraryDataset.getDataTypeClass());
       Assert.assertNotNull(libraryDataset.getState());
+    }
+  }
+  
+  /**
+   * Tests deleting a library successfully.
+   */
+  @Test
+  public void testDeleteLibrarySuccess() {
+    LibrariesClient client = IntegrationTest.getLibrariesClient();
+    Library testLibrary = IntegrationTest.createTestLibrary(client, "test-delete-library" + UUID.randomUUID().toString());
+    assert testLibrary != null : "Library could not be created";
+    assert client.getLibraryContents(testLibrary.getId()) != null : "Invalid library contents";
+    
+    ClientResponse clientResponse = client.deleteLibraryRequest(testLibrary.getId());
+    assert 200 == clientResponse.getStatus() : "Invalid status code";
+  }
+  
+  /**
+   * Tests deleting a library and failing.
+   */
+  @Test
+  public void testDeleteLibraryFail() {
+    LibrariesClient client = IntegrationTest.getLibrariesClient();
+    
+    try {
+      client.deleteLibraryRequest("invalid");
+    } catch (GalaxyResponseException e) {
+      assert 400 == e.getStatusCode() : "Invalid status code";
     }
   }
 }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
@@ -120,7 +120,7 @@ public class LibrariesTest {
     assert testLibrary != null : "Library could not be created";
     assert client.getLibraryContents(testLibrary.getId()) != null : "Invalid library contents";
     
-    ClientResponse clientResponse = client.deleteLibraryResponse(testLibrary.getId());
+    ClientResponse clientResponse = client.deleteLibraryRequest(testLibrary.getId());
     assert 200 == clientResponse.getStatus() : "Invalid status code";
   }
   
@@ -132,7 +132,7 @@ public class LibrariesTest {
     LibrariesClient client = IntegrationTest.getLibrariesClient();
     
     try {
-      client.deleteLibraryResponse("invalid");
+      client.deleteLibraryRequest("invalid");
     } catch (GalaxyResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";
     }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
@@ -120,7 +120,7 @@ public class LibrariesTest {
     assert testLibrary != null : "Library could not be created";
     assert client.getLibraryContents(testLibrary.getId()) != null : "Invalid library contents";
     
-    ClientResponse clientResponse = client.deleteLibraryRequest(testLibrary.getId());
+    ClientResponse clientResponse = client.deleteLibraryResponse(testLibrary.getId());
     assert 200 == clientResponse.getStatus() : "Invalid status code";
   }
   
@@ -132,7 +132,7 @@ public class LibrariesTest {
     LibrariesClient client = IntegrationTest.getLibrariesClient();
     
     try {
-      client.deleteLibraryRequest("invalid");
+      client.deleteLibraryResponse("invalid");
     } catch (GalaxyResponseException e) {
       assert 400 == e.getStatusCode() : "Invalid status code";
     }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/LibrariesTest.java
@@ -1,16 +1,12 @@
 package com.github.jmchilton.blend4j.galaxy;
 
-import static org.testng.AssertJUnit.*;
-
 import com.github.jmchilton.blend4j.galaxy.beans.FileLibraryUpload;
 import com.github.jmchilton.blend4j.galaxy.beans.FilesystemPathsLibraryUpload;
 import com.github.jmchilton.blend4j.galaxy.beans.Library;
 import com.github.jmchilton.blend4j.galaxy.beans.LibraryContent;
 import com.github.jmchilton.blend4j.galaxy.beans.LibraryDataset;
 import com.github.jmchilton.blend4j.galaxy.beans.LibraryFolder;
-import com.github.jmchilton.blend4j.galaxy.beans.LibraryUpload;
 import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
 
 import java.io.File;
 import java.util.List;

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/WorkflowsTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/WorkflowsTest.java
@@ -270,7 +270,7 @@ public class WorkflowsTest {
     WorkflowDetails workflowDetails = client.showWorkflow(workflow.getId());
     assert !workflowDetails.isDeleted() : "Workflow is deleted";
     
-    client.deleteWorkflowResponse(workflow.getId());
+    client.deleteWorkflowRequest(workflow.getId());
     
     workflowDetails = client.showWorkflow(workflow.getId());
     assert workflowDetails.isDeleted() : "Workflow is not deleted";
@@ -291,7 +291,7 @@ public class WorkflowsTest {
     }
     
     try {
-      client.deleteWorkflowResponse(workflow.getId());
+      client.deleteWorkflowRequest(workflow.getId());
     } catch (UniformInterfaceException e) {
       assert 400 == e.getResponse().getStatus() : "Invalid status code";
     }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/WorkflowsTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/WorkflowsTest.java
@@ -1,5 +1,7 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import static org.testng.AssertJUnit.*;
+
 import com.github.jmchilton.blend4j.galaxy.beans.Workflow;
 import com.github.jmchilton.blend4j.galaxy.beans.WorkflowDetails;
 import com.github.jmchilton.blend4j.galaxy.beans.WorkflowInputDefinition;
@@ -14,10 +16,13 @@ import com.github.jmchilton.blend4j.galaxy.beans.collection.request.HistoryDatas
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.CollectionResponse;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -29,11 +34,15 @@ public class WorkflowsTest {
   private static final String TEST_WORKFLOW_COLLECTION_LIST = "TestWorkflowCollectionList";
   private GalaxyInstance instance;
   private WorkflowsClient client;
+  
+  private String testWorkflow1Contents;
 
   @BeforeMethod
-  public void init() {
+  public void init() throws IOException {
     instance = TestGalaxyInstance.get();
     client = instance.getWorkflowsClient();
+    
+    testWorkflow1Contents = Resources.asCharSource(getClass().getResource(TEST_WORKFLOW_NAME + ".ga"), Charsets.UTF_8).read();
   }
   
   private String ensureHasTestWorkflow1() {
@@ -252,7 +261,41 @@ public class WorkflowsTest {
     // TODO: Verify outputs...
   }
   
-
+  /**
+   * Tests successfully deleting a workflow.
+   */
+  @Test
+  public void deleteWorkflowRequestSuccess() {
+    Workflow workflow = client.importWorkflow(testWorkflow1Contents);
+    WorkflowDetails workflowDetails = client.showWorkflow(workflow.getId());
+    assert !workflowDetails.isDeleted() : "Workflow is deleted";
+    
+    client.deleteWorkflowResponse(workflow.getId());
+    
+    workflowDetails = client.showWorkflow(workflow.getId());
+    assert workflowDetails.isDeleted() : "Workflow is not deleted";
+  }
+  
+  /**
+   * Tests failing to deleting an invalid workflow.
+   */
+  @Test
+  public void deleteWorkflowRequestFail() {
+    Workflow workflow = client.importWorkflow(testWorkflow1Contents);
+    
+    try {
+      client.showWorkflow("invalid");
+      fail("The invalid workflow above exists");
+    } catch (UniformInterfaceException e) {
+      assert 400 == e.getResponse().getStatus() : "Invalid status code";
+    }
+    
+    try {
+      client.deleteWorkflowResponse(workflow.getId());
+    } catch (UniformInterfaceException e) {
+      assert 400 == e.getResponse().getStatus() : "Invalid status code";
+    }
+  }
   
   private WorkflowInputs prepParameterTest() throws InterruptedException {
     final String historyId = TestHelpers.getTestHistoryId(instance);


### PR DESCRIPTION
This adds the methods to delete Histories, Data Libraries, and Workflows.  This can be accomplished by running the methods:

```java
HistoriesClient.deleteHistory(String historyId);
LibrariesClient.deleteLibraryResponse(String libraryId);
WorkflowsClient.deleteWorkflowResponse(String workflowId);
```

The `HistoriesClient.deleteHistory` will return a `HistoryDeleteResponse` representing the information returned from a DELETE operation.  Deleting libraries or workflows will just return a `ClientResponse` (specific response objects for each could be added though).

Also, `HistoriesClient.deleteHistory` does not allow for purging of histories.  This is due to a bug in Java 6 and 7 which disallows sending a body along with a DELETE request (see http://bugs.java.com/view_bug.do?bug_id=7157360 and http://stackoverflow.com/questions/12670169/not-able-to-invoke-an-delete-web-service-in-rest-jersey/20075713#20075713).

This can be tested if you have Galaxy by running `mvn test -Dtest.galaxy.key=key -Dtest.galaxy.instance=http://localhost:8080`