### PR TITLE
Add support for accessing job details from the Galaxy API

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstance.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstance.java
@@ -26,4 +26,11 @@ public interface GalaxyInstance {
   String getGalaxyUrl();
   
   String getApiKey();
+  
+  /**
+   * Get a client for interacting with Galaxy's Jobs API.
+   * 
+   * @return a jobs client for interacting with the Jobs API for this instance.
+   */
+  JobsClient getJobsClient();
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstanceImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstanceImpl.java
@@ -57,5 +57,10 @@ class GalaxyInstanceImpl implements GalaxyInstance {
     return webResourceFactory.getApiKey();
   }
 
-
+  /**
+   * {@inheritDoc}
+   */
+  public JobsClient getJobsClient() {
+	  return new JobsClientImpl(this);
+  }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClient.java
@@ -21,11 +21,21 @@ public interface JobsClient {
 	 * @return a collection of all jobs executed by Galaxy.
 	 */
 	public List<Job> getJobs();
-	
+
+	/**
+	 * Get all jobs executed by Galaxy for a specific history.
+	 * 
+	 * @param historyId
+	 *            the history id to load jobs for.
+	 * @return the collection of jobs corresponding to the history.
+	 */
+	public List<Job> getJobsForHistory(final String historyId);
+
 	/**
 	 * Show the details of a specific job execution.
 	 * 
-	 * @param id the job id
+	 * @param id
+	 *            the job id
 	 * @return the details of a job.
 	 */
 	public JobDetails showJob(final String id);

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClient.java
@@ -1,0 +1,32 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+import java.util.List;
+
+import com.github.jmchilton.blend4j.galaxy.beans.Job;
+import com.github.jmchilton.blend4j.galaxy.beans.JobDetails;
+
+/**
+ * Client for interacting with Galaxy's Job API.
+ * 
+ * @author Franklin Bristow franklin.bristow@phac-aspc.gc.ca
+ *
+ */
+public interface JobsClient {
+
+	/**
+	 * Get *all* jobs executed by Galaxy. **WARNING**: This may take a long time
+	 * to execute, depending on how many jobs Galaxy has executed in its
+	 * history.
+	 * 
+	 * @return a collection of all jobs executed by Galaxy.
+	 */
+	public List<Job> getJobs();
+	
+	/**
+	 * Show the details of a specific job execution.
+	 * 
+	 * @param id the job id
+	 * @return the details of a job.
+	 */
+	public JobDetails showJob(final String id);
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClientImpl.java
@@ -36,4 +36,12 @@ public class JobsClientImpl extends Client implements JobsClient {
 		return super.show(id, JobDetails.class);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public List<Job> getJobsForHistory(String historyId) {
+		return get(getWebResource().queryParam("history_id", historyId), new TypeReference<List<Job>>() {
+		});
+	}
+
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/JobsClientImpl.java
@@ -1,0 +1,39 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+import java.util.List;
+
+import org.codehaus.jackson.type.TypeReference;
+
+import com.github.jmchilton.blend4j.galaxy.beans.Job;
+import com.github.jmchilton.blend4j.galaxy.beans.JobDetails;
+
+/**
+ * Implementation for interacting with Galaxy's Job API.
+ * 
+ * @author Franklin Bristow franklin.bristow@phac-aspc.gc.ca
+ *
+ */
+public class JobsClientImpl extends Client implements JobsClient {
+
+	JobsClientImpl(GalaxyInstanceImpl galaxyInstance) {
+		super(galaxyInstance, "jobs");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<Job> getJobs() {
+		return get(new TypeReference<List<Job>>() {
+		});
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public JobDetails showJob(final String id) {
+		return super.show(id, JobDetails.class);
+	}
+
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Job.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Job.java
@@ -1,0 +1,45 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import java.util.Date;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Job extends GalaxyObject {
+	@JsonProperty("state")
+	private String state;
+	@JsonProperty("tool_id")
+	private String toolId;
+	@JsonProperty("create_time")
+	private Date created;
+	@JsonProperty("update_time")
+	private Date updated;
+	
+	public final String getState() {
+		return state;
+	}
+	public final void setState(String state) {
+		this.state = state;
+	}
+	public final String getToolId() {
+		return toolId;
+	}
+	public final void setToolId(String toolId) {
+		this.toolId = toolId;
+	}
+	public final Date getCreated() {
+		return created;
+	}
+	public final void setCreated(Date created) {
+		this.created = created;
+	}
+	public final Date getUpdated() {
+		return updated;
+	}
+	public final void setUpdated(Date updated) {
+		this.updated = updated;
+	}
+	
+	
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/JobDetails.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/JobDetails.java
@@ -1,0 +1,31 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class JobDetails extends Job {
+	@JsonProperty("command_line")
+	private String commandLine;
+	
+	@JsonProperty("exit_code")
+	private Integer exitCode;
+	
+	public Integer getExitCode() {
+		return exitCode;
+	}
+
+	public void setExitCode(final Integer exitCode) {
+		this.exitCode = exitCode;
+	}
+
+	public String getCommandLine() {
+		return this.commandLine;
+	}
+	
+	public void setCommandLine(final String commandLine) {
+		this.commandLine = commandLine;
+	}
+
+}

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/JobsTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/JobsTest.java
@@ -1,0 +1,51 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.github.jmchilton.blend4j.galaxy.beans.Job;
+import com.github.jmchilton.blend4j.galaxy.beans.JobDetails;
+
+/**
+ * Tests for Galaxy's Jobs API.
+ * 
+ * @author Franklin Bristow franklin.bristow@phac-aspc.gc.ca
+ *
+ */
+public class JobsTest {
+	private GalaxyInstance instance;
+	private JobsClient client;
+
+	@BeforeMethod
+	public void init() {
+		instance = TestGalaxyInstance.get();
+		client = instance.getJobsClient();
+	}
+
+	@Test
+	public void testGetJobs() {
+		final List<Job> jobs = client.getJobs();
+		assert jobs != null;
+		assert !jobs.isEmpty();
+
+		for (final Job job : jobs) {
+			assert job.getId() != null;
+		}
+	}
+	
+	@Test
+	public void testGetJobDetails() {
+		final List<Job> jobs = client.getJobs();
+		assert jobs != null;
+		assert !jobs.isEmpty();
+		
+		final Job job = jobs.iterator().next();
+		final JobDetails deets = client.showJob(job.getId());
+		
+		assert deets != null;
+		assert deets.getCommandLine() != null;
+		assert deets.getExitCode() != null;
+	}
+}

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/JobsTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/JobsTest.java
@@ -1,10 +1,12 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.github.jmchilton.blend4j.galaxy.beans.History;
 import com.github.jmchilton.blend4j.galaxy.beans.Job;
 import com.github.jmchilton.blend4j.galaxy.beans.JobDetails;
 
@@ -17,11 +19,13 @@ import com.github.jmchilton.blend4j.galaxy.beans.JobDetails;
 public class JobsTest {
 	private GalaxyInstance instance;
 	private JobsClient client;
+	private HistoriesClient hClient;
 
 	@BeforeMethod
 	public void init() {
 		instance = TestGalaxyInstance.get();
 		client = instance.getJobsClient();
+		hClient = instance.getHistoriesClient();
 	}
 
 	@Test
@@ -34,18 +38,48 @@ public class JobsTest {
 			assert job.getId() != null;
 		}
 	}
-	
+
 	@Test
 	public void testGetJobDetails() {
 		final List<Job> jobs = client.getJobs();
 		assert jobs != null;
 		assert !jobs.isEmpty();
-		
+
 		final Job job = jobs.iterator().next();
 		final JobDetails deets = client.showJob(job.getId());
-		
+
 		assert deets != null;
 		assert deets.getCommandLine() != null;
 		assert deets.getExitCode() != null;
+	}
+
+	/**
+	 * check that the jobs filtered by history id are a subset of the full set
+	 * of jobs.
+	 */
+	@Test
+	public void testGetJobsForHistory() {
+		final List<Job> allJobs = client.getJobs();
+
+		assert allJobs != null;
+		assert !allJobs.isEmpty();
+
+		final List<History> histories = hClient.getHistories();
+		assert histories != null;
+		assert !histories.isEmpty();
+
+		final Iterator<History> historyIterator = histories.iterator();
+		History history; 
+		List<Job> historyJobs;
+		do {
+			history  = historyIterator.next();
+			historyJobs = client.getJobsForHistory(history.getId());
+		} while(historyJobs.size() == 0 && historyIterator.hasNext());
+		
+		assert historyJobs != null;
+		assert !historyJobs.isEmpty();
+		
+		assert allJobs.size() >= historyJobs.size();
+		assert allJobs.containsAll(historyJobs);
 	}
 }


### PR DESCRIPTION
This pull request completes a feature to provide primitive access to the Galaxy Jobs API, specifically to access the `command_line` and `exit_code` attributes of a job execution.