### PR TITLE
Tool data client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.github.jmchilton.galaxybootstrap</groupId>
       <artifactId>galaxybootstrap</artifactId>
-      <version>0.7.0-SNAPSHOT-dff7dde138108f814b01db7be701d429e21c3f43</version>
+      <version>0.7.0-SNAPSHOT-ffc97d55aafedc2262696dc908ad7bbb07f6e77</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.github.jmchilton.galaxybootstrap</groupId>
       <artifactId>galaxybootstrap</artifactId>
-      <version>0.7.0-SNAPSHOT-93faad7e2c2155a53341679161e65a09376b3207</version>
+      <version>0.7.0-SNAPSHOT-dff7dde138108f814b01db7be701d429e21c3f43</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <version>3.0.0</version>
       <optional>true</optional><!-- needed only for annotations -->
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>16.0.1</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.github.jmchilton.galaxybootstrap</groupId>
       <artifactId>galaxybootstrap</artifactId>
-      <version>0.6.0</version>
+      <version>0.7.0-SNAPSHOT-93faad7e2c2155a53341679161e65a09376b3207</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -67,7 +67,34 @@ public class BaseClient {
   protected ClientResponse deleteResponse(final WebResource webResource) {
     return deleteResponse(webResource, true);
   }
-  
+
+  /**
+   * Gets the response for a DELETE request.
+   * @param webResource The {@link WebResource} to send the request to.
+   * @param requestEntity The request entity.
+   * @return The {@link ClientResponse} for this request.
+   * @throws ResponseException If the response was not successful.
+   */
+  protected ClientResponse deleteResponse(final WebResource webResource, java.lang.Object requestEntity) {
+    return deleteResponse(webResource, requestEntity, true);
+  }
+
+  /**
+   * Gets the response for a DELETE request.
+   * @param webResource The {@link WebResource} to send the request to.
+   * @param requestEntity The request entity.
+   * @param checkResponse True if an exception should be thrown on failure, false otherwise.
+   * @return The {@link ClientResponse} for this request.
+   * @throws ResponseException If the response was not successful.
+   */
+  protected ClientResponse deleteResponse(final WebResource webResource, java.lang.Object requestEntity, final boolean checkResponse) {
+    final ClientResponse response = webResource.type(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).delete(ClientResponse.class, requestEntity);
+    if(checkResponse) {
+      this.checkResponse(response);
+    }
+    return response;
+  }
+
   /**
    * Gets the response for a DELETE request.
    * @param webResource The {@link WebResource} to send the request to.

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstance.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstance.java
@@ -15,6 +15,8 @@ public interface GalaxyInstance {
 
   ToolsClient getToolsClient();
 
+  ToolDataClient getToolDataClient();
+
   ConfigurationClient getConfigurationClient();
   
   ToolShedRepositoriesClient getRepositoriesClient();

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstanceImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/GalaxyInstanceImpl.java
@@ -36,6 +36,10 @@ class GalaxyInstanceImpl implements GalaxyInstance {
   public ToolsClient getToolsClient() {
     return new ToolsClientImpl(this);
   }
+
+  public ToolDataClient getToolDataClient() {
+    return new ToolDataClientImpl(this);
+  }
   
   public ConfigurationClient getConfigurationClient() {
     return new ConfigurationClientImpl(this);

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
@@ -1,13 +1,25 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
+import com.sun.jersey.api.client.ClientResponse;
+
 import java.util.List;
-import java.util.Map;
 
 public interface ToolDataClient {
+    ClientResponse showDataTableRequest(String dataTableId);
 
-    public List getDataTables();
+    /**
+     * Get a list of all Tool Data Tables stored in Galaxy.
+     *
+     * @return the list of Tool Data Tables installed in Galaxy.
+     */
+    public List<TabularToolDataTable> getDataTables();
 
-    public Map showDataTable(String dataTableId);
-
-    public Map reloadDataTable(String dataTableId);
+    /**
+     * Show details about the specified tool.
+     *
+     * @param dataTableId the Tool Data Table to look up.
+     * @return details about the Tool Data Table.
+     */
+    public TabularToolDataTable showDataTable(final String dataTableId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
@@ -1,0 +1,4 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+public interface ToolDataClient {
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
@@ -9,11 +9,39 @@ public interface ToolDataClient {
     ClientResponse showDataTableRequest(String dataTableId);
 
     /**
+     * Delete an item from a data table.
+     * @param dataTableId ID of the data table
+     * @param values list of column contents, there must be a value for all the columns of the data table
+     * @return A {@link ClientResponse} for the deleted tool data table items. The status code
+     *         provided by {@link ClientResponse#getClientResponseStatus()} should
+     *         be verified for success.
+     */
+    ClientResponse deleteDataTableRequest(final String dataTableId, final List<String> values);
+
+    /**
      * Get a list of all Tool Data Tables stored in Galaxy.
      *
      * @return the list of Tool Data Tables installed in Galaxy.
      */
-    public List<TabularToolDataTable> getDataTables();
+    List<TabularToolDataTable> getDataTables();
+
+    /**
+     * Show details about the specified tool.
+     *
+     * @param dataTableId the Tool Data Table to look up.
+     * @return updated details about the Tool Data Table.
+     */
+    // TabularToolDataTable reloadDataTable(final String dataTableId);
+
+    /**
+     * Show details about the specified tool.
+     *
+     * @param dataTableId the Tool Data Table to look up.
+     * @return A {@link ClientResponse} for the reloaded tool data table. The status code
+     *         provided by {@link ClientResponse#getClientResponseStatus()} should
+     *         be verified for success.
+     */
+    ClientResponse reloadDataTableRequest(final String dataTableId);
 
     /**
      * Show details about the specified tool.
@@ -21,5 +49,5 @@ public interface ToolDataClient {
      * @param dataTableId the Tool Data Table to look up.
      * @return details about the Tool Data Table.
      */
-    public TabularToolDataTable showDataTable(final String dataTableId);
+    TabularToolDataTable showDataTable(final String dataTableId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClient.java
@@ -1,4 +1,13 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import java.util.List;
+import java.util.Map;
+
 public interface ToolDataClient {
+
+    public List getDataTables();
+
+    public Map showDataTable(String dataTableId);
+
+    public Map reloadDataTable(String dataTableId);
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -4,7 +4,6 @@ import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import com.sun.jersey.api.client.ClientResponse;
 
 import java.util.List;
-import java.util.Map;
 
 public class ToolDataClientImpl extends Client implements ToolDataClient {
     ToolDataClientImpl(GalaxyInstanceImpl galaxyInstance) {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -1,0 +1,4 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+public class ToolDataClientImpl {
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -21,6 +21,6 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
     }
 
     public TabularToolDataTable showDataTable(final String dataTableId) {
-        return super.getWebResource(dataTableId).get(TabularToolDataTable.class);
+        return super.show(dataTableId, TabularToolDataTable.class);
     }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -1,4 +1,25 @@
 package com.github.jmchilton.blend4j.galaxy;
 
-public class ToolDataClientImpl {
+import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
+import com.sun.jersey.api.client.ClientResponse;
+
+import java.util.List;
+import java.util.Map;
+
+public class ToolDataClientImpl extends Client implements ToolDataClient {
+    ToolDataClientImpl(GalaxyInstanceImpl galaxyInstance) {
+        super(galaxyInstance, "tool_data");
+    }
+
+    public ClientResponse showDataTableRequest(String dataTableId) {
+        return null;
+    }
+
+    public List<TabularToolDataTable> getDataTables() {
+        return null;
+    }
+
+    public Map showDataTable(String dataTableId) {
+        return null;
+    }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -4,9 +4,12 @@ import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import com.sun.jersey.api.client.ClientResponse;
 import org.codehaus.jackson.type.TypeReference;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ToolDataClientImpl extends Client implements ToolDataClient {
+
     ToolDataClientImpl(GalaxyInstanceImpl galaxyInstance) {
         super(galaxyInstance, "tool_data");
     }
@@ -16,7 +19,9 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
     }
 
     public ClientResponse deleteDataTableRequest(final String dataTableId, final List<String> values) {
-        return deleteResponse(getWebResource(dataTableId));
+        Map requestEntity = new HashMap();
+        requestEntity.put("values", String.join("\t", values));
+        return deleteResponse(getWebResource(dataTableId), requestEntity);
     }
 
     public List<TabularToolDataTable> getDataTables() {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -13,7 +13,7 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
     }
 
     public ClientResponse showDataTableRequest(String dataTableId) {
-        return null;
+        return super.show(dataTableId, ClientResponse.class);
     }
 
     public List<TabularToolDataTable> getDataTables() {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -21,6 +21,6 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
     }
 
     public TabularToolDataTable showDataTable(final String dataTableId) {
-        return null;
+        return super.getWebResource(dataTableId).get(TabularToolDataTable.class);
     }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -4,7 +4,6 @@ import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import com.sun.jersey.api.client.ClientResponse;
 import org.codehaus.jackson.type.TypeReference;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ToolDataClientImpl extends Client implements ToolDataClient {
@@ -16,8 +15,16 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
         return super.show(dataTableId, ClientResponse.class);
     }
 
+    public ClientResponse deleteDataTableRequest(final String dataTableId, final List<String> values) {
+        return deleteResponse(getWebResource(dataTableId));
+    }
+
     public List<TabularToolDataTable> getDataTables() {
         return get(new TypeReference<List<TabularToolDataTable>>() {});
+    }
+
+    public ClientResponse reloadDataTableRequest(final String dataTableId) {
+        return getResponse(getWebResource(dataTableId).path("reload"));
     }
 
     public TabularToolDataTable showDataTable(final String dataTableId) {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -2,7 +2,9 @@ package com.github.jmchilton.blend4j.galaxy;
 
 import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import com.sun.jersey.api.client.ClientResponse;
+import org.codehaus.jackson.type.TypeReference;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ToolDataClientImpl extends Client implements ToolDataClient {
@@ -15,7 +17,7 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
     }
 
     public List<TabularToolDataTable> getDataTables() {
-        return null;
+        return get(new TypeReference<List<TabularToolDataTable>>() {});
     }
 
     public TabularToolDataTable showDataTable(final String dataTableId) {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/ToolDataClientImpl.java
@@ -19,7 +19,7 @@ public class ToolDataClientImpl extends Client implements ToolDataClient {
         return null;
     }
 
-    public Map showDataTable(String dataTableId) {
+    public TabularToolDataTable showDataTable(final String dataTableId) {
         return null;
     }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/JobInputOutput.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/JobInputOutput.java
@@ -5,7 +5,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 public class JobInputOutput extends GalaxyObject {
   public static enum Source {
-    library(), hda();
+    library(), hda(), ldda();
 
     private Source() {
 

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -1,0 +1,34 @@
+package com.github.jmchilton.blend4j.galaxy.beans;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TabularToolDataTable extends GalaxyObject {
+    private String name;
+
+    private List<String> columns;
+
+    private List<String> fields;
+
+    @JsonProperty("name")
+    protected void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @JsonProperty("columns")
+    protected void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+}

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -60,7 +60,6 @@ public class TabularToolDataTable extends GalaxyObject {
         List<List<String>> rows = getFields();
         List<String> fields = new ArrayList<String>();
         for (List<String> row : rows) {
-            System.out.println(row.get(valueIndex));
             if (row.get(valueIndex).equals(value)) {
                 fields = row;
             }
@@ -74,7 +73,6 @@ public class TabularToolDataTable extends GalaxyObject {
         List<List<String>> rows = getFields();
         Map<String, String> fields = new HashMap<String, String>();
         for (List<String> row : rows) {
-            System.out.println(row.get(valueIndex));
             if (row.get(valueIndex).equals(value)) {
                 for (int i = 0; i < columns.size(); i++) {
                     fields.put(columns.get(i), row.get(i));

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -3,15 +3,15 @@ package com.github.jmchilton.blend4j.galaxy.beans;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-import java.util.List;
+import java.util.ArrayList;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TabularToolDataTable extends GalaxyObject {
     private String name;
 
-    private List<String> columns;
+    private ArrayList<String> columns;
 
-    private List<String> fields;
+    private ArrayList<ArrayList<String>> fields;
 
     @JsonProperty("name")
     protected void setName(final String name) {
@@ -23,20 +23,20 @@ public class TabularToolDataTable extends GalaxyObject {
     }
 
     @JsonProperty("columns")
-    protected void setColumns(final List<String> columns) {
+    protected void setColumns(final ArrayList<String> columns) {
         this.columns = columns;
     }
 
-    public List<String> getColumns() {
+    public ArrayList<String> getColumns() {
         return this.columns;
     }
 
     @JsonProperty("fields")
-    protected void setFields(final List<String> fields) {
+    protected void setFields(final ArrayList<ArrayList<String>> fields) {
         this.fields = fields;
     }
 
-    public List<String> getFields() {
+    public ArrayList<ArrayList<String>> getFields() {
         return this.fields;
     }
 

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -4,14 +4,15 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TabularToolDataTable extends GalaxyObject {
     private String name;
 
-    private ArrayList<String> columns;
+    private List<String> columns;
 
-    private ArrayList<ArrayList<String>> fields;
+    private List<List<String>> fields;
 
     @JsonProperty("name")
     protected void setName(final String name) {
@@ -23,20 +24,20 @@ public class TabularToolDataTable extends GalaxyObject {
     }
 
     @JsonProperty("columns")
-    protected void setColumns(final ArrayList<String> columns) {
+    protected void setColumns(final List<String> columns) {
         this.columns = columns;
     }
 
-    public ArrayList<String> getColumns() {
+    public List<String> getColumns() {
         return this.columns;
     }
 
     @JsonProperty("fields")
-    protected void setFields(final ArrayList<ArrayList<String>> fields) {
+    protected void setFields(final List<List<String>> fields) {
         this.fields = fields;
     }
 
-    public ArrayList<ArrayList<String>> getFields() {
+    public List<List<String>> getFields() {
         return this.fields;
     }
 

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -4,7 +4,9 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TabularToolDataTable extends GalaxyObject {
@@ -41,4 +43,60 @@ public class TabularToolDataTable extends GalaxyObject {
         return this.fields;
     }
 
+    public List<String> getValues() {
+        List<String> columns = getColumns();
+        int valueIndex = columns.indexOf("value");
+        List<List<String>> rows = getFields();
+        List<String> values = new ArrayList<String>();
+        for (List<String> row : rows) {
+            values.add(row.get(valueIndex));
+        }
+        return values;
+    }
+
+    public List<String> getFieldsListForValue(String value) {
+        List<String> columns = getColumns();
+        int valueIndex = columns.indexOf("value");
+        List<List<String>> rows = getFields();
+        List<String> fields = new ArrayList<String>();
+        for (List<String> row : rows) {
+            System.out.println(row.get(valueIndex));
+            if (row.get(valueIndex).equals(value)) {
+                fields = row;
+            }
+        }
+        return fields;
+    }
+
+    public Map<String, String> getFieldsMapForValue(String value) {
+        List<String> columns = getColumns();
+        int valueIndex = columns.indexOf("value");
+        List<List<String>> rows = getFields();
+        Map<String, String> fields = new HashMap<String, String>();
+        for (List<String> row : rows) {
+            System.out.println(row.get(valueIndex));
+            if (row.get(valueIndex).equals(value)) {
+                for (int i = 0; i < columns.size(); i++) {
+                    fields.put(columns.get(i), row.get(i));
+                }
+            }
+        }
+        return fields;
+    }
+
+    public List<String> getFieldsForColumn(String column) {
+        List<String> columns = getColumns();
+        int columnIndex = columns.indexOf(column);
+        List<List<String>> rows = getFields();
+        List<String> fields = new ArrayList<String>();
+        for (List<String> row : rows) {
+            fields.add(row.get(columnIndex));
+        }
+        return fields;
+    }
+
+    public String getField(String value, String column) {
+        String field = getFieldsMapForValue(value).get(column);
+        return field;
+    }
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/TabularToolDataTable.java
@@ -23,12 +23,21 @@ public class TabularToolDataTable extends GalaxyObject {
     }
 
     @JsonProperty("columns")
-    protected void setName(final String name) {
-        this.name = name;
+    protected void setColumns(final List<String> columns) {
+        this.columns = columns;
     }
 
-    public String getName() {
-        return this.name;
+    public List<String> getColumns() {
+        return this.columns;
+    }
+
+    @JsonProperty("fields")
+    protected void setFields(final List<String> fields) {
+        this.fields = fields;
+    }
+
+    public List<String> getFields() {
+        return this.fields;
     }
 
 }

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/WorkflowInputDefinition.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/WorkflowInputDefinition.java
@@ -1,8 +1,13 @@
 package com.github.jmchilton.blend4j.galaxy.beans;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
 public class WorkflowInputDefinition {
   private String value;
   private String label;
+  @JsonProperty("uuid")
+  private String uuid;
 
   public void setValue(final String value) {
     this.value = value;
@@ -18,5 +23,13 @@ public class WorkflowInputDefinition {
 
   public String getLabel() {
     return label;
+  }
+
+  public void setUuid(final String uuid) {
+    this.uuid = uuid;
+  }
+
+  public String getUuid() {
+    return uuid;
   }
 }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
@@ -27,9 +27,9 @@ public class TestGalaxyInstance {
   @BeforeSuite
   public static void bootStrapGalaxy() throws URISyntaxException, IOException {
     if(getTestApiKey() == null) {
-      DownloadProperties downloadProperties = DownloadProperties.forGalaxyCentral();
+      DownloadProperties downloadProperties = DownloadProperties.forLatestRelease();
       if(Boolean.getBoolean(System.getProperty("galaxy.bootstrap.github", "false"))){
-        downloadProperties = DownloadProperties.wgetGithubCentral();
+        downloadProperties = DownloadProperties.wgetGithubMaster();
       }
       final BootStrapper bootStrapper = new BootStrapper(downloadProperties);
       bootStrapper.setupGalaxy();
@@ -100,7 +100,7 @@ public class TestGalaxyInstance {
 
     // set configuration file in Galaxy for custom tools
     galaxyProperties.setAppProperty("tool_config_file",
-        "tool_conf.xml,shed_tool_conf.xml,tool_conf_test.xml");
+        "config/tool_conf.xml.sample,config/shed_tool_conf.xml.sample,tool_conf_test.xml");
   }
 
   @AfterSuite

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
@@ -27,7 +27,7 @@ public class TestGalaxyInstance {
   @BeforeSuite
   public static void bootStrapGalaxy() throws URISyntaxException, IOException {
     if(getTestApiKey() == null) {
-      DownloadProperties downloadProperties = DownloadProperties.forLatestRelease();
+      DownloadProperties downloadProperties = DownloadProperties.forRelease("v17.01");
       if(Boolean.getBoolean(System.getProperty("galaxy.bootstrap.github", "false"))){
         downloadProperties = DownloadProperties.wgetGithubMaster();
       }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
@@ -95,7 +95,7 @@ public class TestGalaxyInstance {
         new File(collectionExampleToolDirectory,"collection_list.xml");
     copyFile(collectionExampleToolSource, collectionExampleToolDestination);
 
-    File testToolConfigDestination = new File(galaxyRootFile, "config/tool_conf_test.xml");
+    File testToolConfigDestination = new File(galaxyRootFile, "tool_conf_test.xml");
     copyFile(testToolConfigSource, testToolConfigDestination);
 
     // set configuration file in Galaxy for custom tools

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/TestGalaxyInstance.java
@@ -115,7 +115,7 @@ public class TestGalaxyInstance {
   static GalaxyInstance get() {
     final String galaxyInstanceUrl = getTestInstanceUrl();
     final String galaxyApiKey = getTestApiKey();
-    return GalaxyInstanceFactory.get(galaxyInstanceUrl, galaxyApiKey);
+    return GalaxyInstanceFactory.get(galaxyInstanceUrl, galaxyApiKey, true);
   }
 
   static String getTestApiKey() {

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -23,7 +23,7 @@ public class ToolDataTest {
         assert ! toolDataTables.isEmpty();
 
         for (final TabularToolDataTable toolDataTable : toolDataTables) {
-            assert toolDataTable.getId() != null;
+            assert toolDataTable.getName() != null;
         }
     }
 }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -1,0 +1,29 @@
+package com.github.jmchilton.blend4j.galaxy;
+
+import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class ToolDataTest {
+    private GalaxyInstance instance;
+    private ToolDataClient client;
+
+    @BeforeMethod
+    public void init() {
+        instance = TestGalaxyInstance.get();
+        client = instance.getToolDataClient();
+    }
+
+    @Test
+    public void testGetToolData() {
+        final List<TabularToolDataTable> toolDataTables = client.getDataTables();
+        assert toolDataTables != null;
+        assert ! toolDataTables.isEmpty();
+
+        for (final TabularToolDataTable toolDataTable : toolDataTables) {
+            assert toolDataTable.getId() != null;
+        }
+    }
+}

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -1,5 +1,7 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import com.sun.jersey.api.client.ClientResponse;
 import org.testng.annotations.BeforeMethod;
@@ -9,6 +11,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ToolDataTest {
+    private static final Logger logger = LoggerFactory.getLogger(ToolDataTest.class);
+
     private GalaxyInstance instance;
     private ToolDataClient client;
 
@@ -58,15 +62,35 @@ public class ToolDataTest {
     }
 
     @Test
+    public void testDeleteDataTableRequest() {
+        TabularToolDataTable toolDataTable = client.showDataTable("igv_broad_genomes");
+        assert toolDataTable != null;
+        List<String> values = new ArrayList<String>();
+        values.add("hg38");
+        // ClientResponse clientResponse = client.deleteDataTableRequest(toolDataTable.getName(), values);
+        // assert clientResponse != null;
+        // logger.debug(clientResponse.toString());
+    }
+
+    @Test
+    public void testReloadDataTableRequest() {
+        TabularToolDataTable toolDataTable = client.showDataTable("igv_broad_genomes");
+        assert toolDataTable != null;
+        ClientResponse clientResponse = client.reloadDataTableRequest(toolDataTable.getName());
+        assert clientResponse != null;
+        logger.debug(clientResponse.toString());
+    }
+
+    @Test
     public void testTableContents() {
         final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
         assert igvBroadGenomes != null;
 
-        final ArrayList<String> headers = igvBroadGenomes.getColumns();
-        System.out.println(headers.get(0) + "\t" + headers.get(2));
-        System.out.println("----------");
-        for (final ArrayList<String> row : igvBroadGenomes.getFields()) {
-            System.out.println(row.get(0) + "\t" + row.get(2));
+        final List<String> headers = igvBroadGenomes.getColumns();
+        logger.debug(headers.get(0) + "\t" + headers.get(2));
+        logger.debug("----------");
+        for (final List<String> row : igvBroadGenomes.getFields()) {
+            logger.debug(row.get(0) + "\t" + row.get(2));
         }
 
     }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -17,13 +17,14 @@ public class ToolDataTest {
     }
 
     @Test
-    public void testGetToolData() {
+    public void testGetDataTables() {
         final List<TabularToolDataTable> toolDataTables = client.getDataTables();
         assert toolDataTables != null;
         assert ! toolDataTables.isEmpty();
 
         for (final TabularToolDataTable toolDataTable : toolDataTables) {
             assert toolDataTable.getName() != null;
+            System.out.println(toolDataTable.getName());
         }
     }
 }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -1,6 +1,7 @@
 package com.github.jmchilton.blend4j.galaxy;
 
 import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
+import com.sun.jersey.api.client.ClientResponse;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -29,15 +30,29 @@ public class ToolDataTest {
     }
 
     @Test
-    public void testShowDataTables() {
+    public void testShowDataTable() {
         final List<TabularToolDataTable> toolDataTables = client.getDataTables();
         assert toolDataTables != null;
         assert ! toolDataTables.isEmpty();
 
         for (final TabularToolDataTable toolDataTable : toolDataTables) {
             assert toolDataTable.getName() != null;
-            TabularToolDataTable dataTable = client.showDataTable("igv_broad_genomes");
+            TabularToolDataTable dataTable = client.showDataTable(toolDataTable.getName());
+            assert dataTable != null;
+        }
 
+    }
+
+    @Test
+    public void testShowDataTableRequest() {
+        final List<TabularToolDataTable> toolDataTables = client.getDataTables();
+        assert toolDataTables != null;
+        assert ! toolDataTables.isEmpty();
+
+        for (final TabularToolDataTable toolDataTable : toolDataTables) {
+            assert toolDataTable.getName() != null;
+            ClientResponse clientResponse = client.showDataTableRequest(toolDataTable.getName());
+            assert clientResponse != null;
         }
 
     }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class ToolDataTest {
@@ -57,6 +58,7 @@ public class ToolDataTest {
             assert toolDataTable.getName() != null;
             ClientResponse clientResponse = client.showDataTableRequest(toolDataTable.getName());
             assert clientResponse != null;
+            assert 200 == clientResponse.getStatus();
         }
 
     }
@@ -65,11 +67,11 @@ public class ToolDataTest {
     public void testDeleteDataTableRequest() {
         TabularToolDataTable toolDataTable = client.showDataTable("igv_broad_genomes");
         assert toolDataTable != null;
-        List<String> values = new ArrayList<String>();
-        values.add("hg38");
-        // ClientResponse clientResponse = client.deleteDataTableRequest(toolDataTable.getName(), values);
-        // assert clientResponse != null;
-        // logger.debug(clientResponse.toString());
+        List<String> values = new ArrayList<String>(Arrays.asList("Human hg38", "http://s3.amazonaws.com/igv.broadinstitute.org/genomes/hg38.genome", "hg38"));
+        ClientResponse clientResponse = client.deleteDataTableRequest(toolDataTable.getName(), values);
+        assert clientResponse != null;
+        assert 200 == clientResponse.getStatus();
+        logger.debug(clientResponse.toString());
     }
 
     @Test
@@ -78,6 +80,7 @@ public class ToolDataTest {
         assert toolDataTable != null;
         ClientResponse clientResponse = client.reloadDataTableRequest(toolDataTable.getName());
         assert clientResponse != null;
+        assert 200 == clientResponse.getStatus();
         logger.debug(clientResponse.toString());
     }
 

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class ToolDataTest {
     private static final Logger logger = LoggerFactory.getLogger(ToolDataTest.class);
@@ -85,17 +86,37 @@ public class ToolDataTest {
     }
 
     @Test
-    public void testTableContents() {
+    public void testGetFieldsForValue() {
         final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
         assert igvBroadGenomes != null;
-
-        final List<String> headers = igvBroadGenomes.getColumns();
-        logger.debug(headers.get(0) + "\t" + headers.get(2));
-        logger.debug("----------");
-        for (final List<String> row : igvBroadGenomes.getFields()) {
-            logger.debug(row.get(0) + "\t" + row.get(2));
-        }
-
+        final List<String> fieldsList = igvBroadGenomes.getFieldsListForValue("hg38");
+        assert fieldsList != null;
+        final Map<String, String> fieldsMap = igvBroadGenomes.getFieldsMapForValue("hg38");
+        assert fieldsMap != null;
+        assert fieldsMap.get("value").equals("hg38");
     }
 
+    @Test
+    public void testGetValues() {
+        final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
+        assert igvBroadGenomes != null;
+        List<String> values = igvBroadGenomes.getValues();
+        assert values.size() == 156;
+    }
+
+    @Test
+    public void testGetFieldsForColumn() {
+        final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
+        assert igvBroadGenomes != null;
+        List<String> values = igvBroadGenomes.getFieldsForColumn("name");
+        assert values.size() == 156;
+    }
+
+    @Test
+    public void testGetField() {
+        final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
+        assert igvBroadGenomes != null;
+        String field = igvBroadGenomes.getField("hg38", "name");
+        assert field.equals("Human hg38");
+    }
 }

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/ToolDataTest.java
@@ -4,6 +4,7 @@ import com.github.jmchilton.blend4j.galaxy.beans.TabularToolDataTable;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ToolDataTest {
@@ -24,7 +25,35 @@ public class ToolDataTest {
 
         for (final TabularToolDataTable toolDataTable : toolDataTables) {
             assert toolDataTable.getName() != null;
-            System.out.println(toolDataTable.getName());
         }
     }
+
+    @Test
+    public void testShowDataTables() {
+        final List<TabularToolDataTable> toolDataTables = client.getDataTables();
+        assert toolDataTables != null;
+        assert ! toolDataTables.isEmpty();
+
+        for (final TabularToolDataTable toolDataTable : toolDataTables) {
+            assert toolDataTable.getName() != null;
+            TabularToolDataTable dataTable = client.showDataTable("igv_broad_genomes");
+
+        }
+
+    }
+
+    @Test
+    public void testTableContents() {
+        final TabularToolDataTable igvBroadGenomes = client.showDataTable("igv_broad_genomes");
+        assert igvBroadGenomes != null;
+
+        final ArrayList<String> headers = igvBroadGenomes.getColumns();
+        System.out.println(headers.get(0) + "\t" + headers.get(2));
+        System.out.println("----------");
+        for (final ArrayList<String> row : igvBroadGenomes.getFields()) {
+            System.out.println(row.get(0) + "\t" + row.get(2));
+        }
+
+    }
+
 }

--- a/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflow1.ga
+++ b/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflow1.ga
@@ -24,7 +24,8 @@
             "tool_id": null, 
             "tool_state": "{\"name\": \"WorkflowInput1\"}", 
             "tool_version": null, 
-            "type": "data_input", 
+            "type": "data_input",
+            "uuid": "3232b621-1c0e-4449-a0b5-1067bf798d56",
             "user_outputs": []
         }, 
         "1": {
@@ -47,7 +48,8 @@
             "tool_id": null, 
             "tool_state": "{\"name\": \"WorkflowInput2\"}", 
             "tool_version": null, 
-            "type": "data_input", 
+            "type": "data_input",
+            "uuid": "ea7a0edd-37ba-4fc6-8e23-496e33e36868",
             "user_outputs": []
         }, 
         "2": {
@@ -80,8 +82,10 @@
             "tool_id": "cat1", 
             "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"null\", \"chromInfo\": \"\\\"/home/john/workspace/galaxy-central/tool-data/shared/ucsc/chrom/?.len\\\"\", \"queries\": \"[{\\\"input2\\\": null, \\\"__index__\\\": 0}]\"}", 
             "tool_version": "1.0.0", 
-            "type": "tool", 
+            "type": "tool",
+            "uuid": "6fa1b23b-51af-4b4f-9135-35cf151c5a3c",
             "user_outputs": []
         }
-    }
+    },
+    "uuid": "27d4c823-4dd9-4495-9ff4-a3df6b554535"
 }

--- a/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflowCollectionList.ga
+++ b/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflowCollectionList.ga
@@ -24,7 +24,8 @@
             "tool_id": null, 
             "tool_state": "{\"collection_type\": \"list\", \"name\": \"input_list\"}", 
             "tool_version": null, 
-            "type": "data_collection_input", 
+            "type": "data_collection_input",
+            "uuid": "73bb50c5-10fa-4f6c-8b12-aafed369689a",
             "user_outputs": []
         }, 
         "1": {
@@ -53,8 +54,10 @@
             "tool_id": "collection_list", 
             "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"in\": \"null\"}", 
             "tool_version": "0.1.0", 
-            "type": "tool", 
+            "type": "tool",
+            "uuid": "28b555a6-eb27-491a-8515-7ec9c447f147",
             "user_outputs": []
         }
-    }
+    },
+    "uuid": "c5675c83-2bbe-44bd-9935-5f41812a66f0"
 }

--- a/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflowRandomlines.ga
+++ b/src/test/resources/com/github/jmchilton/blend4j/galaxy/TestWorkflowRandomlines.ga
@@ -24,7 +24,8 @@
             "tool_id": null, 
             "tool_state": "{\"name\": \"Input Dataset\"}", 
             "tool_version": null, 
-            "type": "data_input", 
+            "type": "data_input",
+            "uuid": "33b12960-5cb4-40b2-ad22-b32467c1ca52",
             "user_outputs": []
         }, 
         "1": {
@@ -53,7 +54,8 @@
             "tool_id": "random_lines1", 
             "tool_state": "{\"input\": \"null\", \"seed_source\": \"{\\\"__current_case__\\\": 0, \\\"seed_source_selector\\\": \\\"no_seed\\\"}\", \"__rerun_remap_job_id__\": null, \"num_lines\": \"\\\"5\\\"\", \"__page__\": 0}", 
             "tool_version": "2.0.1", 
-            "type": "tool", 
+            "type": "tool",
+            "uuid": "09d18c95-4361-4eec-8c09-19d3c4b9cfb3",
             "user_outputs": []
         }, 
         "2": {
@@ -82,8 +84,10 @@
             "tool_id": "random_lines1", 
             "tool_state": "{\"input\": \"null\", \"seed_source\": \"{\\\"__current_case__\\\": 0, \\\"seed_source_selector\\\": \\\"no_seed\\\"}\", \"__rerun_remap_job_id__\": null, \"num_lines\": \"\\\"2\\\"\", \"__page__\": 0}", 
             "tool_version": "2.0.1", 
-            "type": "tool", 
+            "type": "tool",
+            "uuid": "0a55f2f4-09e3-41e4-aa56-7aabe50b7246",
             "user_outputs": []
         }
-    }
+    },
+    "uuid": "bec8e849-ab54-4f6a-a693-f3ed9de0f817"
 }


### PR DESCRIPTION
- Use @dfornika galaxy-bootstrap (at commit ffc97d55aafedc2262696dc908ad7bbb07f6e776) in testing. This allows us to spin up a Galaxy v17.01 instance from github sources.
- Added UUIDs to workflow and uuid property, getter, setter to WorkflowInputDefinition
- Added classes to interact with Galaxy Tool Data Tables:
  - beans.TabularToolDataTable
  - ToolDataClient (and ToolDataClientImpl)
- Added basic tests for ToolDataClient
